### PR TITLE
docs: clarify env file copy commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,27 @@ Projeto exclusivo da equipe Harpion desenvolvido com foco em qualidade e seguran
 ### Back-end
 1. `cd backend`
 2. `composer install`
-3. Copie `.env.example` para `.env` e configure as variáveis
+3. Copie `.env.example` para `.env` e configure as variáveis:
+
+   **Linux/macOS**
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   **Windows (CMD)**
+
+   ```cmd
+   copy .env.example .env
+   ```
+
+   **Windows (PowerShell)**
+
+   ```powershell
+   Copy-Item .env.example .env
+   ```
+
+   Você também pode copiar o arquivo manualmente usando um gerenciador de arquivos.
 4. `php artisan serve` para iniciar a API
 
 ## Testes e lint

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,7 +16,27 @@ Projeto exclusivo da equipe Harpion desenvolvido com foco em qualidade e seguran
 ## Instalação
 1. Clone este repositório.
 2. Execute `npm install` ou `bun install` para instalar as dependências.
-3. Copie o arquivo `.env.example` para `.env` e configure suas variáveis de ambiente (como `VITE_API_URL` apontando para a API do Laravel).
+3. Copie o arquivo `.env.example` para `.env` e configure suas variáveis de ambiente (como `VITE_API_URL` apontando para a API do Laravel):
+
+   **Linux/macOS**
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   **Windows (CMD)**
+
+   ```cmd
+   copy .env.example .env
+   ```
+
+   **Windows (PowerShell)**
+
+   ```powershell
+   Copy-Item .env.example .env
+   ```
+
+   Você também pode copiar o arquivo manualmente usando um gerenciador de arquivos.
 
 ## Ambiente de desenvolvimento
 Para iniciar o servidor de desenvolvimento execute:


### PR DESCRIPTION
## Summary
- document copy command for Linux/macOS, Windows CMD, and PowerShell in backend README
- mirror copy instructions in frontend README

## Testing
- no tests run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68b385bda26c8327ba874843c4c30bde