### PR TITLE
fix(auth): validate and return user data on registration

### DIFF
--- a/backend/app/Http/Controllers/AdmController.php
+++ b/backend/app/Http/Controllers/AdmController.php
@@ -40,15 +40,21 @@ class AdmController extends Controller
 
     public function cadastroAdm(Request $request)
     {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:table_administrador,email',
+            'password' => 'required|min:8',
+        ]);
+
         $adm = new AdmModel;
 
-        $adm->name = $request->name;
-        $adm->email = $request->email;
-        $adm->password = Hash::make($request->password);
+        $adm->name = $validated['name'];
+        $adm->email = $validated['email'];
+        $adm->password = Hash::make($validated['password']);
 
         $adm->save();
 
-        return response()->json(['message' => 'Administrador cadastrado com sucesso!'], 201);
+        return response()->json($adm, 201);
     }
 
     public function loginAdmin(Request $request)

--- a/backend/app/Http/Controllers/AlunoController.php
+++ b/backend/app/Http/Controllers/AlunoController.php
@@ -48,14 +48,23 @@ class AlunoController extends Controller
 
     public function insertAlunoAPI(Request $request)
     {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:aluno,email',
+            'password' => 'required|min:8',
+            'ra' => 'required|string',
+            'semestre' => 'required|string',
+            'telefone' => 'nullable|string',
+        ]);
+
         $aluno = new AlunoModel;
 
-        $aluno->name = $request->name;
-        $aluno->email = $request->email;
-        $aluno->password = Hash::make($request->password);
-        $aluno->ra = $request->ra;
-        $aluno->semestre = $request->semestre;
-        $aluno->telefone = $request->telefone;
+        $aluno->name = $validated['name'];
+        $aluno->email = $validated['email'];
+        $aluno->password = Hash::make($validated['password']);
+        $aluno->ra = $validated['ra'];
+        $aluno->semestre = $validated['semestre'];
+        $aluno->telefone = $validated['telefone'] ?? null;
 
         $aluno->save();
 

--- a/backend/app/Http/Controllers/professorController.php
+++ b/backend/app/Http/Controllers/professorController.php
@@ -21,28 +21,47 @@ class professorController extends Controller
 
     public function cadastroProfessor(Request $request)
     {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'cpf' => 'required|string|unique:table_professor,cpf',
+            'especializacao' => 'required|string',
+            'formacao' => 'required|string',
+            'registro_profissional' => 'required|string',
+            'telefone' => 'nullable|string',
+            'email' => 'required|email|unique:table_professor,email',
+            'password' => 'required|min:8',
+        ]);
+
         $professor = new ProfModel;
 
-        $professor->name = $request->name;
-        $professor->cpf = $request->cpf;
-        $professor->especializacao = $request->especializacao;
-        $professor->formacao = $request->formacao;
-        $professor->registro_profissional = $request->registro_profissional;
-        $professor->telefone = $request->telefone;
-        $professor->email = $request->email;
-        $professor->password = Hash::make($request->password);
+        $professor->name = $validated['name'];
+        $professor->cpf = $validated['cpf'];
+        $professor->especializacao = $validated['especializacao'];
+        $professor->formacao = $validated['formacao'];
+        $professor->registro_profissional = $validated['registro_profissional'];
+        $professor->telefone = $validated['telefone'] ?? null;
+        $professor->email = $validated['email'];
+        $professor->password = Hash::make($validated['password']);
 
         $professor->save();
 
-        return response()->json(['message' => 'Professor cadastrado com sucesso!'], 201);
+        return response()->json($professor, 201);
     }
 
     public function loginProfessor(Request $request)
     {
+        $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+
         $professor = ProfModel::where('email', $request->email)->first();
 
         if ($professor && Hash::check($request->password, $professor->password)) {
-            return response()->json(['message' => 'Login realizado com sucesso!'], 200);
+            return response()->json([
+                'message' => 'Login realizado com sucesso!',
+                'professor' => $professor,
+            ], 200);
         }
 
         return response()->json(['message' => 'Credenciais inválidas!'], 401);


### PR DESCRIPTION
## Summary
- add validation for student registration
- ensure professor registration/login validate input and return user data
- return created admin object with validation

## Testing
- `npm run lint`
- `npm test` *(fails: No tests found)*
- `vendor/bin/pint`
- `php artisan test`

Closes #1

------
https://chatgpt.com/codex/tasks/task_e_68b396e7a7d08327884a98812a112681