### PR TITLE
feat: update homepage technologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Projeto exclusivo da equipe Harpion desenvolvido com foco em qualidade e seguran
 - React
 - shadcn-ui
 - Tailwind CSS
+- Laravel
+- PHP
 
 ## Pré-requisitos
 - Node.js 18 ou superior

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -91,9 +91,13 @@ const Footer = () => {
             <div className="space-y-2">
               <h4 className="text-white font-medium text-sm">Tecnologias:</h4>
               <div className="flex flex-wrap gap-2">
-                <span className="bg-slate-800 text-slate-300 px-2 py-1 rounded text-xs">React</span>
+                <span className="bg-slate-800 text-slate-300 px-2 py-1 rounded text-xs">Vite</span>
                 <span className="bg-slate-800 text-slate-300 px-2 py-1 rounded text-xs">TypeScript</span>
-                <span className="bg-slate-800 text-slate-300 px-2 py-1 rounded text-xs">Tailwind</span>
+                <span className="bg-slate-800 text-slate-300 px-2 py-1 rounded text-xs">React</span>
+                <span className="bg-slate-800 text-slate-300 px-2 py-1 rounded text-xs">shadcn-ui</span>
+                <span className="bg-slate-800 text-slate-300 px-2 py-1 rounded text-xs">Tailwind CSS</span>
+                <span className="bg-slate-800 text-slate-300 px-2 py-1 rounded text-xs">Laravel</span>
+                <span className="bg-slate-800 text-slate-300 px-2 py-1 rounded text-xs">PHP</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- expand technologies list in home footer to include backend stack
- document backend technologies in README

## Testing
- `npm run lint`
- `npm test` *(fails: No tests found)*
- `vendor/bin/pint`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b39a8e480c83278c65e0263f093a35