### PR TITLE
fix: allow nullable telefone in aluno migration

### DIFF
--- a/backend/database/migrations/2025_08_05_110912_create_aluno_table.php
+++ b/backend/database/migrations/2025_08_05_110912_create_aluno_table.php
@@ -20,7 +20,9 @@ return new class extends Migration
             $table->string('password');
             $table->integer('ra');
             $table->string('semestre');
-            $table->string('telefone');
+            // Allow telefone to be nullable to prevent database errors when the
+            // field is not provided during aluno creation.
+            $table->string('telefone')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
## Summary
- allow `telefone` column to be nullable to prevent insert errors when phone is missing

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpunit`

Relates to #1

------
https://chatgpt.com/codex/tasks/task_e_68b39f14fb348327a74021f9ace51a13